### PR TITLE
remove floodfill

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -36,6 +36,7 @@ Blocked-Cmds:
 
 # Commands that only superadmins and higher can do, blocks aliases automatically when real command is blocked {include a / before the command for worldedit commands}
 SA-Commands:
+  - /floodfill
   - kick
   - co
   - socialspy


### PR DESCRIPTION
Floodfill is an annoying tool used for griefers. Admins cant even track the griefer for its untraceable.
